### PR TITLE
Kap-2 Referenzen-Datei iSAQB-internen Hinweis in Kommentar aendern

### DIFF
--- a/docs/02-procedures/references.adoc
+++ b/docs/02-procedures/references.adoc
@@ -3,14 +3,18 @@
 <<ambok>>, <<bentea>>, <<benteb>>, <<burlton>>, <<gharbi>>, <<greefhorst>>, <<grigoriu>>, <<hanschkeb>>, <<lankhorst>>, <<morris>>, <<optland>>, <<reussner>>, <<ross>>, <<tiemeyer>>, <<tiwary>>, <<togaf>>, <<ulrich>>, <<weill>>, <<ziemann>>
 
 // tag::REMARK[]
-[NOTE]
+// [NOTE]
 
 // tag::DE[]
+////
 Eine Quelle wird über `<<label>>` referenziert. Dieses muss in `99-references/00-references.adoc` definiert sein.
+////
 // end::DE[]
 
 // tag::EN[]
+////
 A reference source is referenced via `<<label>>`. The label has to be defined in `99-references/00-references.adoc`.
+////
 // end::EN[]
 
 // end::REMARK[]


### PR DESCRIPTION
Ein iSAQB-interner Hinweis wurde in das PDF des Curriculum übernommen