### PR TITLE
Fix Missing Tag Warnings

### DIFF
--- a/docs/00b-basics/00-basics.adoc
+++ b/docs/00b-basics/00-basics.adoc
@@ -15,3 +15,13 @@ include::04-prerequisites-for-this-training.adoc[{include_configuration}]
 include::05-curriculum-outline.adoc[{include_configuration}]
 
 include::06-complementary-information.adoc[{include_configuration}]
+
+
+// tag::DE[]
+
+// end::DE[]
+
+
+// tag::EN[]
+
+// end::EN[]

--- a/docs/01-basic-terms/references.adoc
+++ b/docs/01-basic-terms/references.adoc
@@ -3,5 +3,16 @@
 <<ambok>>, <<benteb>>, <<burlton>>, <<cobit>>, <<gharbi>>, <<greefhorst>>, <<grigoriu>>, <<hanschkeb>>, <<hanschkec>>, <<itil>>, <<keller>>, <<morris>>, <<optland>>, <<reussner>>, <<ross>>, <<schekkerman>>, <<schwarzer>>, <<tiemeyer>>, <<tiwary>>, <<togaf>>, <<ulrich>>, <<vogel>>, <<ziemann>>
 
 
+// tag::DE[]
+////
+Eine Quelle wird über `<<label>>` referenziert. Dieses muss in `99-references/00-references.adoc` definiert sein.
+////
+// end::DE[]
 
+
+// tag::EN[]
+////
+A reference source is referenced via `<<label>>`. The label has to be defined in `99-references/00-references.adoc`.
+////
+// end::EN[]
 

--- a/docs/03-governance/references.adoc
+++ b/docs/03-governance/references.adoc
@@ -2,5 +2,17 @@
 
 <<cobit>>, <<hanschkea>>, <<johannsen>>, <<optland>>, <<togaf>>, <<weill>>, <<ziemann>>
 
+// tag::DE[]
+////
+Eine Quelle wird über `<<label>>` referenziert. Dieses muss in `99-references/00-references.adoc` definiert sein.
+////
+// end::DE[]
+
+
+// tag::EN[]
+////
+A reference source is referenced via `<<label>>`. The label has to be defined in `99-references/00-references.adoc`.
+////
+// end::EN[]
 
 

--- a/docs/04-interactions/references.adoc
+++ b/docs/04-interactions/references.adoc
@@ -3,3 +3,13 @@
 <<ambok>>, <<greefhorst>>, <<grigoriu>>, <<hohmann>>
 
 
+// tag::DE[]
+////
+Eine Quelle wird über `<<label>>` referenziert. Dieses muss in `99-references/00-references.adoc` definiert sein.
+////
+// end::DE[]
+
+
+// tag::EN[]
+
+// end::EN[]

--- a/docs/98-examples/00-examples.adoc
+++ b/docs/98-examples/00-examples.adoc
@@ -5,3 +5,11 @@ include::01-examples-duration-terms.adoc[{include_configuration}]
 include::02-learning-goals.adoc[{include_configuration}]
 
 //include::references.adoc[{include_configuration}]
+// tag::DE[]
+
+// end::DE[]
+
+
+// tag::EN[]
+
+// end::EN[]

--- a/docs/98-examples/00-structure.adoc
+++ b/docs/98-examples/00-structure.adoc
@@ -4,7 +4,6 @@ include::01-examples-duration-terms.adoc[{include_configuration}]
 
 include::02-learning-goals.adoc[{include_configuration}]
 
-//include::references.adoc[{include_configuration}]
 // tag::DE[]
 
 // end::DE[]

--- a/docs/98-examples/references.adoc
+++ b/docs/98-examples/references.adoc
@@ -1,4 +1,0 @@
-=== {references}
-
-
-

--- a/docs/curriculum-eam.adoc
+++ b/docs/curriculum-eam.adoc
@@ -47,19 +47,13 @@ include::01-basic-terms/00-structure.adoc[{include_configuration}]
 include::02-procedures/00-structure.adoc[{include_configuration}]
 
 <<<
-include::03-repositories/00-structure.adoc[{include_configuration}]
+include::03-governance/00-structure.adoc[{include_configuration}]
 
 <<<
-include::04-governance/00-structure.adoc[{include_configuration}]
+include::04-interactions/00-structure.adoc[{include_configuration}]
 
 <<<
-include::05-interactions/00-structure.adoc[{include_configuration}]
-
-<<<
-include::06-frameworks/00-structure.adoc[{include_configuration}]
-
-<<<
-include::98-examples/00-examples.adoc[{include_configuration}]
+include::98-examples/00-structure.adoc[{include_configuration}]
 
 <<<
 include::99-references/00-references.adoc[{include_configuration}]


### PR DESCRIPTION
- Add `DE` and `EN` tags to files to silence warnings about missing files
- Rename file in `98-examples`  to match the name of the other chapters' files
- Fix includes of renamed chapters in `curriculum-eam.adoc`
- Remove non-existing chapter includes in `curriculum-eam.adoc`

close #40